### PR TITLE
Corrected an issue with translating Long.MIN_VALUE. Math.abs(Long.MIN…

### DIFF
--- a/src/main/java/com/bigspotteddog/number/translator/NumberTranslator.java
+++ b/src/main/java/com/bigspotteddog/number/translator/NumberTranslator.java
@@ -59,7 +59,7 @@ public class NumberTranslator {
                     append(buf, "and");
                 }
             } else {
-                if (number > 1000 && scale == 0 && digits > 0) {
+                if ((number > 1000 || number < -1000) && scale == 0 && digits > 0) {
                     append(buf, "and");
                 }
             }

--- a/src/main/java/com/bigspotteddog/number/translator/NumberTranslator.java
+++ b/src/main/java/com/bigspotteddog/number/translator/NumberTranslator.java
@@ -17,7 +17,7 @@ public class NumberTranslator {
         } else {
             if (number < 0) {
                 append(buf, "negative");
-                translate(number * -1, scale, language, buf);
+                translate(number, scale, language, buf);
             } else {
                 translate(number, scale, language, buf);
             }
@@ -38,6 +38,10 @@ public class NumberTranslator {
         }
 
         digits = digits / (long) Math.pow(1000, scale);
+
+        if (digits < 0) {
+            digits = Math.abs(digits);
+        }
 
         final long segment = digits;
 
@@ -89,10 +93,10 @@ public class NumberTranslator {
     }
 
     protected int getScale(final long number) {
-        long value = Math.abs(number);
+        long value = number;
 
         int scale = -1;
-        while (value > 0) {
+        while (value / 1 != 0) {
             value /= 1000;
             scale++;
         }

--- a/src/test/java/com/bigspotteddog/number/translator/NumberTranslatorTest.java
+++ b/src/test/java/com/bigspotteddog/number/translator/NumberTranslatorTest.java
@@ -292,6 +292,14 @@ public class NumberTranslatorTest extends TestCase {
         assertNotNull(words);
         assertEquals("Negative one hundred and eight", words);
 
+        words = translator.translate(-118, "en-US");
+        assertNotNull(words);
+        assertEquals("Negative one hundred and eighteen", words);
+
+        words = translator.translate(-136, "en-US");
+        assertNotNull(words);
+        assertEquals("Negative one hundred and thirty six", words);
+
         words = translator.translate(-100036007, "en-US");
         assertNotNull(words);
         assertEquals("Negative one hundred million thirty six thousand and seven", words);

--- a/src/test/java/com/bigspotteddog/number/translator/NumberTranslatorTest.java
+++ b/src/test/java/com/bigspotteddog/number/translator/NumberTranslatorTest.java
@@ -266,4 +266,20 @@ public class NumberTranslatorTest extends TestCase {
         String words = translator.translate(-123, "en-US");
         assertEquals("Negative one hundred and twenty three", words);
     }
+
+    public void testScale() {
+        NumberTranslator translator = new NumberTranslator();
+
+        int scale = translator.getScale(Long.MIN_VALUE);
+        assertEquals(6, scale);
+
+        scale = translator.getScale(Long.MAX_VALUE);
+        assertEquals(6, scale);
+    }
+
+    public void testLongMinValue() throws IOException {
+        NumberTranslator translator = new NumberTranslator();
+        String words = translator.translate(Long.MIN_VALUE, "en-US");        
+        assertEquals("Negative nine quintillion two hundred and twenty three quadrillion three hundred and seventy two trillion thirty six billion eight hundred and fifty four million seven hundred and seventy five thousand eight hundred and eight", words);
+    }
 }

--- a/src/test/java/com/bigspotteddog/number/translator/NumberTranslatorTest.java
+++ b/src/test/java/com/bigspotteddog/number/translator/NumberTranslatorTest.java
@@ -279,7 +279,21 @@ public class NumberTranslatorTest extends TestCase {
 
     public void testLongMinValue() throws IOException {
         NumberTranslator translator = new NumberTranslator();
-        String words = translator.translate(Long.MIN_VALUE, "en-US");        
+        String words = translator.translate(Long.MIN_VALUE, "en-US");
         assertEquals("Negative nine quintillion two hundred and twenty three quadrillion three hundred and seventy two trillion thirty six billion eight hundred and fifty four million seven hundred and seventy five thousand eight hundred and eight", words);
+    }
+
+    public void testNegativeAnds() throws IOException {
+        NumberTranslator translator = new NumberTranslator();
+        String words = translator.translate(-1008, "en-US");
+        assertEquals("Negative one thousand and eight", words);
+
+        words = translator.translate(-108, "en-US");
+        assertNotNull(words);
+        assertEquals("Negative one hundred and eight", words);
+
+        words = translator.translate(-100036007, "en-US");
+        assertNotNull(words);
+        assertEquals("Negative one hundred million thirty six thousand and seven", words);
     }
 }


### PR DESCRIPTION
#6 …_VALUE) returns Long.MIN_VALUE so using value > 0 to check for numbers that are non-zero does not work. Small refator to use value / 1 != 0 instead to check if the number is no longer 1 or larger.